### PR TITLE
Made plugin compatible with Vue 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # vue-plugin-load-script [![license](https://img.shields.io/github/license/tserkov/vue-plugin-load-script.svg)]()
-
 A Vue plugin for injecting remote scripts.
+
+Compatible with Vue 3.
 
 ## Install
 
-```bash
+``` bash
 # npm
 npm install --save vue-plugin-load-script
 ```
 
-```bash
+``` bash
 # yarn
 yarn add vue-plugin-load-script
 ```
@@ -17,35 +18,38 @@ yarn add vue-plugin-load-script
 ## Use
 
 ```javascript
-// In main.js
-import LoadScript from "vue-plugin-load-script";
+  // In main.js
+  import { createApp } from "vue";
+  import LoadScript from "vue-plugin-load-script";
 
-app.use(LoadScript);
+  const app = createApp(App);
+  app.use(LoadScript);
+
+  app.mount("#app");
 ```
 
 ```javascript
-// As an instance method inside a component
-this.$loadScript("https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY")
-  .then(() => {
-    // Script is loaded, do something
-  })
-  .catch(() => {
-    // Failed to fetch script
-  });
+  // As an instance method inside a component
+  this.$loadScript("https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY")
+    .then(() => {
+      // Script is loaded, do something
+    })
+    .catch(() => {
+      // Failed to fetch script
+    });
 ```
 
-:zap: **New in 1.2!**
-If you'd like to remove (unload) the script at any point, then call the companion method `$unloadScript` **with the same URL**.
+:zap: __New in 1.2!__
+If you'd like to remove (unload) the script at any point, then call the companion method `$unloadScript` __with the same URL__.
 
 ```javascript
-// As an instance method inside a component
-this.$unloadScript("https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY")
-  .then(() => {
-    // Script was unloaded successfully
-  })
-  .catch(() => {
-    // Script couldn't be found to unload; make sure it was loaded and that you passed the same URL
-  });
+  // As an instance method inside a component
+  this.$unloadScript("https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY")
+    .then(() => {
+      // Script was unloaded successfully
+    })
+    .catch(() => {
+      // Script couldn't be found to unload; make sure it was loaded and that you passed the same URL
+    });
 ```
-
 In most situations, you can just call `this.$unloadScript` and ignore the returned promise.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # vue-plugin-load-script [![license](https://img.shields.io/github/license/tserkov/vue-plugin-load-script.svg)]()
+
 A Vue plugin for injecting remote scripts.
 
 ## Install
 
-``` bash
+```bash
 # npm
 npm install --save vue-plugin-load-script
 ```
 
-``` bash
+```bash
 # yarn
 yarn add vue-plugin-load-script
 ```
@@ -16,52 +17,35 @@ yarn add vue-plugin-load-script
 ## Use
 
 ```javascript
-  // In main.js
-  import LoadScript from 'vue-plugin-load-script';
+// In main.js
+import LoadScript from "vue-plugin-load-script";
 
-  Vue.use(LoadScript);
+app.use(LoadScript);
 ```
 
 ```javascript
-  // As a global method
-  Vue.loadScript("https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY")
-    .then(() => {
-      // Script is loaded, do something
-    })
-    .catch(() => {
-      // Failed to fetch script
-    });
-
-  // As an instance method inside a component
-  this.$loadScript("https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY")
-    .then(() => {
-      // Script is loaded, do something
-    })
-    .catch(() => {
-      // Failed to fetch script
-    });
+// As an instance method inside a component
+this.$loadScript("https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY")
+  .then(() => {
+    // Script is loaded, do something
+  })
+  .catch(() => {
+    // Failed to fetch script
+  });
 ```
 
-:zap: __New in 1.2!__
-If you'd like to remove (unload) the script at any point, then call the companion method `$unloadScript` __with the same URL__.
+:zap: **New in 1.2!**
+If you'd like to remove (unload) the script at any point, then call the companion method `$unloadScript` **with the same URL**.
 
 ```javascript
-  // As a global method
-  Vue.unloadScript("https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY")
-    .then(() => {
-      // Script was unloaded successfully
-    })
-    .catch(() => {
-      // Script couldn't be found to unload; make sure it was loaded and that you passed the same URL
-    });
-
-  // As an instance method inside a component
-  this.$unloadScript("https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY")
-    .then(() => {
-      // Script was unloaded successfully
-    })
-    .catch(() => {
-      // Script couldn't be found to unload; make sure it was loaded and that you passed the same URL
-    });
+// As an instance method inside a component
+this.$unloadScript("https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY")
+  .then(() => {
+    // Script was unloaded successfully
+  })
+  .catch(() => {
+    // Script couldn't be found to unload; make sure it was loaded and that you passed the same URL
+  });
 ```
-In most situations, you can just call `Vue.unloadScript`/`this.$unloadScript` and ignore the returned promise.
+
+In most situations, you can just call `this.$unloadScript` and ignore the returned promise.

--- a/index.js
+++ b/index.js
@@ -6,20 +6,20 @@ const LoadScript = {
         let shouldAppend = false;
         let el = document.querySelector('script[src="' + src + '"]');
         if (!el) {
-          el = document.createElement("script");
-          el.type = "text/javascript";
+          el = document.createElement('script');
+          el.type = 'text/javascript';
           el.async = true;
           el.src = src;
           shouldAppend = true;
-        } else if (el.hasAttribute("data-loaded")) {
+        } else if (el.hasAttribute('data-loaded')) {
           resolve(el);
           return;
         }
 
-        el.addEventListener("error", reject);
-        el.addEventListener("abort", reject);
-        el.addEventListener("load", function loadScriptHandler() {
-          el.setAttribute("data-loaded", true);
+        el.addEventListener('error', reject);
+        el.addEventListener('abort', reject);
+        el.addEventListener('load', function loadScriptHandler() {
+          el.setAttribute('data-loaded', true);
           resolve(el);
         });
 

--- a/index.js
+++ b/index.js
@@ -1,25 +1,25 @@
 const LoadScript = {
-  install: function (Vue) {
-    Vue.loadScript = Vue.prototype.$loadScript = function (src) { // eslint-disable-line no-param-reassign
+  install: function (app) {
+    app.loadScript = app.config.globalProperties.$loadScript = function (src) {
+      // eslint-disable-line no-param-reassign
       return new Promise(function (resolve, reject) {
         let shouldAppend = false;
         let el = document.querySelector('script[src="' + src + '"]');
         if (!el) {
-          el = document.createElement('script');
-          el.type = 'text/javascript';
+          el = document.createElement("script");
+          el.type = "text/javascript";
           el.async = true;
           el.src = src;
           shouldAppend = true;
-        }
-        else if (el.hasAttribute('data-loaded')) {
+        } else if (el.hasAttribute("data-loaded")) {
           resolve(el);
           return;
         }
 
-        el.addEventListener('error', reject);
-        el.addEventListener('abort', reject);
-        el.addEventListener('load', function loadScriptHandler() {
-          el.setAttribute('data-loaded', true);
+        el.addEventListener("error", reject);
+        el.addEventListener("abort", reject);
+        el.addEventListener("load", function loadScriptHandler() {
+          el.setAttribute("data-loaded", true);
           resolve(el);
         });
 
@@ -27,7 +27,10 @@ const LoadScript = {
       });
     };
 
-    Vue.unloadScript = Vue.prototype.$unloadScript = function (src) { // eslint-disable-line no-param-reassign
+    app.unloadScript = app.config.globalProperties.$unloadScript = function (
+      src
+    ) {
+      // eslint-disable-line no-param-reassign
       return new Promise(function (resolve, reject) {
         const el = document.querySelector('script[src="' + src + '"]');
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const LoadScript = {
   install: function (app) {
-    app.loadScript = app.config.globalProperties.$loadScript = function (src) {
+    app.config.globalProperties.$loadScript = function (src) {
       // eslint-disable-line no-param-reassign
       return new Promise(function (resolve, reject) {
         let shouldAppend = false;
@@ -27,9 +27,7 @@ const LoadScript = {
       });
     };
 
-    app.unloadScript = app.config.globalProperties.$unloadScript = function (
-      src
-    ) {
+    app.config.globalProperties.$unloadScript = function (src) {
       // eslint-disable-line no-param-reassign
       return new Promise(function (resolve, reject) {
         const el = document.querySelector('script[src="' + src + '"]');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-plugin-load-script",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "A Vue plugin for injecting remote scripts",
   "main": "index.js",
   "repository": "https://github.com/tserkov/vue-plugin-load-script",


### PR DESCRIPTION
The plugin did not work with Vue 3 as it was. 

There has been a change to the global API in Vue 3 which is breaking. The global Vue object is no longer available, but rather the app instance. Because of this we cannot add functions by `Vue.loadScript = ` or `Vue.prototype.$loadScript = `. Vue 3 has an API for adding `$loadScript` to the `this` object in components like this: `app.config.globalProperties.$loadScript = ` which is what i did.

If you want to read more: https://v3.vuejs.org/guide/plugins.html#writing-a-plugin 

Keep in mind, this change does not work with Vue 2, so it needs to be a new version only for those using Vue 3.
