### PR TITLE
Import Vue in type definition file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+.DS_Store

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import Vue from "vue";
+
 declare module "vue-plugin-load-script";
 
 declare module "vue/types/vue" {

--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
   "repository": "https://github.com/tserkov/vue-plugin-load-script",
   "author": "tserkov <james.churchard@gmail.com>",
   "license": "MIT",
-  "typings": "./index.d.ts"
+  "typings": "./index.d.ts",
+  "devDependencies": {
+    "vue": "^2.6.14"
+  }
 }


### PR DESCRIPTION
See issue #30 

Adding the import statement (for reasons described in the issue above) requires adding Vue as a dependency. I did commit a lockfile, as I don't know your preference between npm & yarn. Also, I'm of course open to lowering the version of Vue listed in the dependencies; I just added the current 2.x version.

Let me know what you think.